### PR TITLE
Add ability to add custom headers to spiffe client

### DIFF
--- a/api/workload/x509_client.go
+++ b/api/workload/x509_client.go
@@ -29,6 +29,9 @@ type X509ClientConfig struct {
 
 	// A logging interface which is satisfied by stdlib logger. Can be nil.
 	Log logrus.StdLogger
+
+	// Headers are additional headers to send with RPC requests to the SPIFFE Workload API.
+	Headers map[string]string
 }
 
 // NewX509Client creates a new Workload API client for the X509SVID service.

--- a/api/workload/x509_stream.go
+++ b/api/workload/x509_stream.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 
 	"github.com/spiffe/spire/api/workload/dial"
+	"github.com/spiffe/spire/internal/spiffecontext"
 	"github.com/spiffe/spire/proto/api/workload"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
 // x509Stream maintains an open connection to the X509-SVID service of the SPIFFE Workload API and
@@ -144,8 +144,7 @@ func (x *x509Stream) newClient() (workload.SpiffeWorkloadAPIClient, error) {
 func (x *x509Stream) newStream() (workload.SpiffeWorkloadAPI_FetchX509SVIDClient, context.CancelFunc, error) {
 	bo := newBackoff(x.c.Timeout)
 
-	ctx := context.Background()
-	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("workload.spiffe.io", "true"))
+	ctx := spiffecontext.NewOutgoing(context.Background(), x.c.Headers)
 	ctx, cancel := context.WithCancel(ctx)
 
 	streamChan := make(chan workload.SpiffeWorkloadAPI_FetchX509SVIDClient, 1)

--- a/cmd/spire-agent/cli/api/common.go
+++ b/cmd/spire-agent/cli/api/common.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	workload_dial "github.com/spiffe/spire/api/workload/dial"
+	"github.com/spiffe/spire/internal/spiffecontext"
 	"github.com/spiffe/spire/proto/api/workload"
-	"google.golang.org/grpc/metadata"
 )
 
 var (
@@ -51,8 +51,7 @@ func newWorkloadClient(ctx context.Context, socketPath string, timeout time.Dura
 }
 
 func (c *workloadClient) prepareContext(ctx context.Context) (context.Context, func()) {
-	header := metadata.Pairs("workload.spiffe.io", "true")
-	ctx = metadata.NewOutgoingContext(ctx, header)
+	ctx = spiffecontext.NewOutgoing(ctx, nil)
 	if c.timeout > 0 {
 		return context.WithTimeout(ctx, c.timeout)
 	}

--- a/functional/tools/workload/workload.go
+++ b/functional/tools/workload/workload.go
@@ -10,8 +10,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/spiffe/spire/internal/spiffecontext"
 	workload "github.com/spiffe/spire/proto/api/workload"
-	"google.golang.org/grpc/metadata"
 )
 
 // Workload is the component that consumes Workload API and renews certs
@@ -41,8 +41,7 @@ func (w *Workload) RunDaemon(ctx context.Context) error {
 	timeoutTimer := time.NewTimer(time.Second * time.Duration(w.timeout))
 	defer timeoutTimer.Stop()
 
-	header := metadata.Pairs("workload.spiffe.io", "true")
-	ctx = metadata.NewOutgoingContext(ctx, header)
+	ctx = spiffecontext.NewOutgoing(ctx, nil)
 
 	stream, err := w.workloadClient.FetchX509SVID(ctx, &workload.X509SVIDRequest{})
 	if err != nil {

--- a/internal/spiffecontext/spiffecontext.go
+++ b/internal/spiffecontext/spiffecontext.go
@@ -1,0 +1,25 @@
+package spiffecontext
+
+import (
+	"context"
+
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	_headerSpiffeWorkloadKey   = "workload.spiffe.io"
+	_headerSpiffeWorkloadValue = "true"
+)
+
+// NewOutgoing returns a new SPIFFE context with metadata for speaking to the Workload API.
+func NewOutgoing(ctx context.Context, headers map[string]string) context.Context {
+	md := metadata.New(headers)
+	md.Set(_headerSpiffeWorkloadKey, _headerSpiffeWorkloadValue)
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+// IsValidIncomingContext verifies that this is a valid SPIFFE request context.
+func IsValidIncomingContext(ctx context.Context) bool {
+	md, ok := metadata.FromIncomingContext(ctx)
+	return ok && len(md[_headerSpiffeWorkloadKey]) == 1 && md[_headerSpiffeWorkloadKey][0] == _headerSpiffeWorkloadValue
+}

--- a/pkg/agent/endpoints/workload/handler.go
+++ b/pkg/agent/endpoints/workload/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/sirupsen/logrus"
+	"github.com/spiffe/spire/internal/spiffecontext"
 	attestor "github.com/spiffe/spire/pkg/agent/attestor/workload"
 	"github.com/spiffe/spire/pkg/agent/catalog"
 	"github.com/spiffe/spire/pkg/agent/manager"
@@ -27,7 +28,6 @@ import (
 	"github.com/zeebo/errs"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -281,8 +281,7 @@ func (h *Handler) composeJWTBundlesResponse(update *cache.WorkloadUpdate) (*work
 }
 
 func (h *Handler) startCall(ctx context.Context) (int32, []*common.Selector, telemetry.Metrics, func(), error) {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok || len(md["workload.spiffe.io"]) != 1 || md["workload.spiffe.io"][0] != "true" {
+	if !spiffecontext.IsValidIncomingContext(ctx) {
 		return 0, nil, nil, nil, status.Errorf(codes.InvalidArgument, "Security header missing from request")
 	}
 


### PR DESCRIPTION
**Affected functionality**
We require the ability to add custom internal routing headers.

**Description of change**
This adds the ability to add custom headers in SPIFFE client config. It doesn't thread changes to the CLI because CLI interop isn't a priority yet.
